### PR TITLE
[date-fns v1] added format() locale support + parse() validity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,26 @@ Read more about jsDeliver versioning on their [website](http://www.jsdelivr.com/
 
 ## Configuration
 
-### Locale support
+### Locale support via scale options
 
-date-fns, contrary to moment.js which uses a global locale configuration, requires the date-fns locale object to be tagged on to each `format()` call, which requires the locale to be explicitly set via the `adapters.date` option: [Chart.js documentation on adapters.date](https://www.chartjs.org/docs/latest/axes/cartesian/time.html?h=adapter)
+date-fns requires a date-fns locale object to be tagged on to each `format()` call, which requires the locale to be explicitly set via the `adapters.date` option: [Chart.js documentation on adapters.date](https://www.chartjs.org/docs/latest/axes/cartesian/time.html?h=adapter)
 
 For example:
 ```javascript
-{ locale: de }
+// import date-fns locale:
+import {de} from 'date-fns/locale';
+
+// scale options:
+{
+    adapters: {
+        date: {
+            locale: de
+        }
+    }
+}
 ```
 
-Further, read the [Chart.js documention](https://www.chartjs.org/docs/latest) for other possible date/time related options. For example, the time scale [`time.*` options](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options) can be overridden using the [date-fns tokens](https://date-fns.org/v1.30.1/docs/format).
+Further, read the [Chart.js documentation](https://www.chartjs.org/docs/latest) for other possible date/time related options. For example, the time scale [`time.*` options](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options) can be overridden using the [date-fns tokens](https://date-fns.org/v1.30.1/docs/format).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Read more about jsDeliver versioning on their [website](http://www.jsdelivr.com/
 
 ## Configuration
 
-Locale support:
+### Locale support
+
 date-fns, contrary to moment.js which uses a global locale configuration, requires the date-fns locale object to be tagged on to each `format()` call, which requires the locale to be explicitly set via the `adapters.date` option: [Chart.js documentation on adapters.date](https://www.chartjs.org/docs/latest/axes/cartesian/time.html?h=adapter)
-eg.
+
+For example:
 ```javascript
 { locale: de }
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ date-fns requires a date-fns locale object to be tagged on to each `format()` ca
 For example:
 ```javascript
 // import date-fns locale:
-import {de} from 'date-fns/locale';
+import de from 'date-fns/locale/de';
 
 // scale options:
 {

--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ Read more about jsDeliver versioning on their [website](http://www.jsdelivr.com/
 
 ## Configuration
 
-No adapter configuration is currently available, read the [Chart.js documention](https://www.chartjs.org/docs/latest) for other possible date/time related options. For example, the time scale [`time.*` options](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options) can be overridden using the [date-fns tokens](https://date-fns.org/v1.30.1/docs/format).
+Locale support:
+date-fns, contrary to moment.js which uses a global locale configuration, requires the date-fns locale object to be tagged on to each `format()` call, which requires the locale to be explicitly set via the `adapters.date` option: [Chart.js documentation on adapters.date](https://www.chartjs.org/docs/latest/axes/cartesian/time.html?h=adapter)
+eg.
+```javascript
+{ locale: de }
+```
+
+Further, read the [Chart.js documention](https://www.chartjs.org/docs/latest) for other possible date/time related options. For example, the time scale [`time.*` options](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options) can be overridden using the [date-fns tokens](https://date-fns.org/v1.30.1/docs/format).
 
 ## Development
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,7 @@ _adapters._date.override({
 	},
 
 	format: function(time, fmt) {
-		const options = this.options ? this.options : {};
-		return format(time, fmt, options);
+		return format(time, fmt, this.options || {});
 	},
 
 	add: function(time, amount, unit) {

--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ _adapters._date.override({
 	},
 
 	format: function(time, fmt) {
-		return format(time, fmt, this.options || {});
+		return format(time, fmt, this.options);
 	},
 
 	add: function(time, amount, unit) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { _adapters, helpers } from 'chart.js';
 import {
-	parse, format,
+	parse, format, isValid,
 	startOfSecond, startOfMinute, startOfHour, startOfDay,
 	startOfWeek, startOfMonth, startOfQuarter, startOfYear,
 	addMilliseconds, addSeconds, addMinutes, addHours,
@@ -32,16 +32,17 @@ _adapters._date.override({
 		return FORMATS;
 	},
 
-	parse: function(value/* , format */) {
+	parse: function(value) {
 		if (helpers.isNullOrUndef(value)) {
 			return null;
 		}
-
-		return parse(value);
+		value = parse(value);
+		return isValid(value) ? value.valueOf() : null;
 	},
 
 	format: function(time, fmt) {
-		return format(time, fmt);
+		const options = this.options ? this.options : {};
+		return format(time, fmt, options);
 	},
 
 	add: function(time, amount, unit) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ _adapters._date.override({
 			return null;
 		}
 		value = parse(value, this.options);
-		return isValid(value) ? value.valueOf() : null;
+		return isValid(value) ? value.getTime() : null;
 	},
 
 	format: function(time, fmt) {

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ _adapters._date.override({
 		if (helpers.isNullOrUndef(value)) {
 			return null;
 		}
-		value = parse(value);
+		value = parse(value, this.options);
 		return isValid(value) ? value.valueOf() : null;
 	},
 


### PR DESCRIPTION
This adds both, a date-fns _locale_ config option to `format()` as well as a validity check for `parse()`.
Please review for merge.