### PR TITLE
Fix formatting of ticks for `day` format

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ var FORMATS = {
 	second: 'h:mm:ss a',
 	minute: 'h:mm a',
 	hour: 'ha',
-	day: 'MMM d',
+	day: 'MMM D',
 	week: 'DD',
 	month: 'MMM YYYY',
 	quarter: '[Q]Q - YYYY',


### PR DESCRIPTION
Fixes this issue:
![image](https://user-images.githubusercontent.com/5667395/57406136-19a4f500-71ae-11e9-83de-ac96f789a0ea.png)

Lowercase `d` in the day format is day of week. Should be an uppercase `D`