### PR TITLE
Remove use of helpers for v3 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ Chart._adapters._date.override({
 	},
 
 	parse: function(value, fmt) {
-		if (Chart.helpers.isNullOrUndef(value)) {
+		if (value === null || typeof value === 'undefined') {
 			return null;
 		}
 		const type = typeof value;


### PR DESCRIPTION
This will let us keep using the same version for v2 and v3. With the recent changes to support tree-shaking if we import the helpers in a v3-compatible way then we will lose v2 compatibility