### PR TITLE
chore(build): build esm target

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "main": "dist/chartjs-adapter-date-fns.js",
+  "module": "dist/chartjs-adapter-date-fns.esm.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/chartjs/chartjs-adapter-date-fns.git"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default [
 		input: 'src/index.js',
 		output: {
 			file: `dist/${name}.js`,
-			banner: banner,
+			banner,
 			format: 'umd',
 			indent: false,
 			globals: {
@@ -54,7 +54,7 @@ export default [
 		input: 'src/index.js',
 		output: {
 			file: `dist/${name}.esm.js`,
-			banner: banner,
+			banner,
 			format: 'esm',
 			indent: false,
 			globals: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,6 +53,23 @@ export default [
 	{
 		input: 'src/index.js',
 		output: {
+			file: `dist/${name}.esm.js`,
+			banner: banner,
+			format: 'esm',
+			indent: false,
+			globals: {
+				'chart.js': 'Chart',
+				'date-fns': 'dateFns'
+			}
+		},
+		external: [
+			'chart.js',
+			'date-fns'
+		]
+	},
+	{
+		input: 'src/index.js',
+		output: {
 			file: `dist/${name}.bundle.js`,
 			format: 'umd',
 			indent: false,


### PR DESCRIPTION
Archived discussion can be found in #15

Export ESM for stable release to allow tree-shaking when using bundling systems.