### PR TITLE
Adds option to override default formats in adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ import {de} from 'date-fns/locale';
 
 Further, read the [Chart.js documentation](https://www.chartjs.org/docs/latest) for other possible date/time related options. For example, the time scale [`time.*` options](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options) can be overridden using the [date-fns tokens](https://date-fns.org/docs/format).
 
+### Display formats options
+
+Chart.js allows you to configure the global display formats via [`time.displayFormats`](https://www.chartjs.org/docs/latest/axes/cartesian/time.html#configuration-options), but these aren’t passed to date-fns.
+
+For example, you can change `time.unit` to `'month'` to use date-fns to display the month, but you cannot use `time.displayFormats` to change the display of `month` from the default of `MMM yyyy` to your custom string `MMMM`.
+
+Instead, you can change these values using `adapters.date.formats`:
+
+```js
+// scale options:
+{
+  adapters: {
+    date: {
+      formats: {
+        month: 'MMMM'
+      }
+    }
+  }
+}
+```
+
+Your modifications will be merged into [the defaults](https://github.com/chartjs/chartjs-adapter-date-fns/blob/a26933d3a14d827f3faa865aa2f01546b7359d60/src/index.js#L15-L26) for this adapter.
+
 ## Development
 
 You first need to install node dependencies (requires [Node.js](https://nodejs.org/)):

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ Chart._adapters._date.override({
 
 	formats: function() {
 		if (this.options && this.options.formats && typeof Object.assign === 'function') {
-			return Object.assign({}, FORMATS, this.options.formats)
+			return Object.assign({}, FORMATS, this.options.formats);
 		}
 
 		return FORMATS;

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,10 @@ Chart._adapters._date.override({
 	_id: 'date-fns', // DEBUG
 
 	formats: function() {
+		if (this.options && this.options.formats && typeof Object.assign === 'function') {
+			return Object.assign({}, FORMATS, this.options.formats)
+		}
+
 		return FORMATS;
 	},
 


### PR DESCRIPTION
I think it’s possible to change `time.scale` with this adapter, but not possible to change `time.displayFormat` using this adapter.

For example, you can change `time.unit` to `'month'` to use date-fns to display the month, but you cannot use `time.displayFormats` to change the display of `month` from the default of `MMM yyyy` to your custom string `MMMM`.

This Pull Request adds an option to pass in formats to modify the default FORMATS object.

If there’s a different way of doing that already, that’s fine too! I intentionally didn’t call it `displayFormats` as it seems confusing to have `time.displayFormats` and also `adapters.data.displayFormats`, but maybe it’s also confusing to have them _not_ match.

This does use `Object.assign` for convenience, which I think works fine based on [Chart.js’ browser support](https://github.com/chartjs/Chart.js/blob/master/.browserslistrc). If that’s an issue, the option could override the whole object instead.