### PR TITLE
Fix peerDependencies of chart.js version <3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "chartjs-adapter-date-fns",
       "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
@@ -29,7 +30,7 @@
         "rollup-plugin-terser": "^7.0.2"
       },
       "peerDependencies": {
-        "chart.js": "^3.0.0"
+        "chart.js": ">=2.8.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "rollup-plugin-terser": "^7.0.2"
   },
   "peerDependencies": {
-    "chart.js": "^3.0.0"
+    "chart.js": ">=2.8.0"
   }
 }


### PR DESCRIPTION
### What?
- set `peerDependencies` for `chart.js` to `>=2.8.0` in `package.json` to match support mentioned in README.md

> Requires [Chart.js](https://github.com/chartjs/Chart.js/releases) 2.8.0 or later and [date-fns](https://date-fns.org/) 2.0.0 or later.

### Why?
There was a [related issue that was closed](https://github.com/chartjs/chartjs-adapter-date-fns/issues/38) which was actually a valid problem I ran into if a project is using npm 7+ and depends on `chart.js` >=2.8.0 and <3.0.0. The code is definitely supported, but the package resolution is broken due to how peerDependencies are resolved since npm 7. 

This change ensures that users can still install this package using older supported versions of chart.js.
