### PR TITLE
Update package.json to resolve #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Chart.js adapter to use date-fns for time functionalities",
   "version": "2.0.1",
   "license": "MIT",
-  "main": "dist/chartjs-adapter-date-fns.js",
-  "module": "dist/chartjs-adapter-date-fns.esm.js",
+  "type": "module",
+  "exports": {
+    ".": "./dist/chartjs-adapter-date-fns.esm.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/chartjs/chartjs-adapter-date-fns.git"


### PR DESCRIPTION
This resolves issues with  `No "exports" main defined in [...]/node_modules/chart.js/package.json`. Compared to the luxon and moment adapters to arrive at this conclusion. May require some further testing, but it appears to resolve the issue for me.